### PR TITLE
Add supplier as input to worker

### DIFF
--- a/core/src/main/java/eu/alehem/tempserver/remote/core/Main.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/Main.java
@@ -5,6 +5,7 @@ import com.pi4j.system.SystemInfo;
 import eu.alehem.tempserver.remote.core.argparser.ArgParser;
 import eu.alehem.tempserver.remote.core.argparser.Arguments;
 import eu.alehem.tempserver.remote.core.exceptions.InvalidArgumentsException;
+import eu.alehem.tempserver.remote.core.measurementsuppliers.TemperatureDS18B20Supplier;
 import eu.alehem.tempserver.remote.core.workers.DatabaseFunction;
 import eu.alehem.tempserver.remote.core.workers.Sender;
 import eu.alehem.tempserver.remote.core.workers.Worker;
@@ -55,7 +56,13 @@ public class Main {
 
     final Sender sender = new Sender(MY_SERIAL, remoteId, serverAddress);
     final DatabaseFunction dbFunc = new DatabaseFunction();
-    final Worker worker = new Worker(sender, dbFunc);
+
+    //TODO: Make this list of suppliers be generated from a parameter so that it is possible to choose which sensors
+    //to use.
+
+    final TemperatureDS18B20Supplier temperatureSupplier = new TemperatureDS18B20Supplier();
+
+    final Worker worker = new Worker(sender, dbFunc, temperatureSupplier);
 
     Runtime.getRuntime().addShutdownHook(new Thread(new Shutdown(worker)));
 

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/MeasurementSupplier.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/MeasurementSupplier.java
@@ -1,9 +1,12 @@
 package eu.alehem.tempserver.remote.core.measurementsuppliers;
 
+import eu.alehem.tempserver.schema.proto.Tempserver;
+
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
  * A supplier that gets measurements to save
  * @param <T> The type of measurement to get
  */
-public interface MeasurementSupplier<T> extends Supplier<T> {}
+public interface MeasurementSupplier extends Supplier<Set<Tempserver.Measurement>> {}

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/TemperatureDS18B20Supplier.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/TemperatureDS18B20Supplier.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * A temperature supplier for the DS18B20 temperature sensor
  */
 @Log4j2
-public class TemperatureDS18B20Supplier implements MeasurementSupplier<Set<Tempserver.Measurement>> {
+public class TemperatureDS18B20Supplier implements MeasurementSupplier {
 
   private static final List<W1Device> PROBES = getTempProbes();
 


### PR DESCRIPTION
Makes the worker generic by adding a supplier as an input method. Also changes the measurementSupplier interface so that it is less generic and must supply a set of measurements

*This has not been tested on a remote*