### PR TITLE
Fix Log4J

### DIFF
--- a/core/src/main/java/eu/alehem/tempserver/remote/core/DatabaseManager.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/DatabaseManager.java
@@ -2,7 +2,6 @@ package eu.alehem.tempserver.remote.core;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import eu.alehem.tempserver.schema.proto.Tempserver;
-
 import java.sql.*;
 import java.util.HashSet;
 import java.util.Set;

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/Main.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/Main.java
@@ -9,6 +9,11 @@ import eu.alehem.tempserver.remote.core.workers.DatabaseFunction;
 import eu.alehem.tempserver.remote.core.workers.Sender;
 import eu.alehem.tempserver.remote.core.workers.Worker;
 import eu.alehem.tempserver.remote.schema.JsonProperties;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.cli.CommandLine;
@@ -17,12 +22,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 @Log4j2
 public class Main {

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/argparser/ArgParser.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/argparser/ArgParser.java
@@ -1,9 +1,14 @@
 package eu.alehem.tempserver.remote.core.argparser;
 
-import org.apache.commons.cli.*;
-
 import java.util.Arrays;
 import java.util.Optional;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 
 public class ArgParser {
 

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/MeasurementSupplier.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/MeasurementSupplier.java
@@ -4,6 +4,7 @@ import java.util.function.Supplier;
 
 /**
  * A supplier that gets measurements to save
+ *
  * @param <T> The type of measurement to get
  */
 public interface MeasurementSupplier<T> extends Supplier<T> {}

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/TemperatureDS18B20Supplier.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/measurementsuppliers/TemperatureDS18B20Supplier.java
@@ -5,26 +5,26 @@ import com.pi4j.component.temperature.impl.TmpDS18B20DeviceType;
 import com.pi4j.io.w1.W1Device;
 import com.pi4j.io.w1.W1Master;
 import eu.alehem.tempserver.schema.proto.Tempserver;
-import lombok.extern.log4j.Log4j2;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.extern.log4j.Log4j2;
 
-/**
- * A temperature supplier for the DS18B20 temperature sensor
- */
+/** A temperature supplier for the DS18B20 temperature sensor */
 @Log4j2
-public class TemperatureDS18B20Supplier implements MeasurementSupplier<Set<Tempserver.Measurement>> {
+public class TemperatureDS18B20Supplier
+    implements MeasurementSupplier<Set<Tempserver.Measurement>> {
 
   private static final List<W1Device> PROBES = getTempProbes();
 
   @Override
   public Set<Tempserver.Measurement> get() {
     log.info("Reading temperature");
-    return PROBES.stream().map(TemperatureDS18B20Supplier::getTemperature).collect(Collectors.toSet());
+    return PROBES.stream()
+        .map(TemperatureDS18B20Supplier::getTemperature)
+        .collect(Collectors.toSet());
   }
 
   private static List<W1Device> getTempProbes() {

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/workers/DatabaseFunction.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/workers/DatabaseFunction.java
@@ -3,14 +3,13 @@ package eu.alehem.tempserver.remote.core.workers;
 import com.google.protobuf.InvalidProtocolBufferException;
 import eu.alehem.tempserver.remote.core.DatabaseManager;
 import eu.alehem.tempserver.schema.proto.Tempserver;
-import lombok.extern.log4j.Log4j2;
-
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Takes a set of temperatures to be sent and makes sure it has the correct size by adding or

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/workers/Sender.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/workers/Sender.java
@@ -2,6 +2,10 @@ package eu.alehem.tempserver.remote.core.workers;
 
 import eu.alehem.tempserver.remote.core.exceptions.ServerCommsFailedException;
 import eu.alehem.tempserver.schema.proto.Tempserver;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.http.HttpResponse;
@@ -10,11 +14,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.HttpClientBuilder;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Function;
 
 @Log4j2
 @AllArgsConstructor

--- a/core/src/main/java/eu/alehem/tempserver/remote/core/workers/Worker.java
+++ b/core/src/main/java/eu/alehem/tempserver/remote/core/workers/Worker.java
@@ -3,14 +3,13 @@ package eu.alehem.tempserver.remote.core.workers;
 import eu.alehem.tempserver.remote.core.DatabaseManager;
 import eu.alehem.tempserver.remote.core.measurementsuppliers.TemperatureDS18B20Supplier;
 import eu.alehem.tempserver.schema.proto.Tempserver;
-import lombok.extern.log4j.Log4j2;
-
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class Worker implements Runnable {

--- a/pom.xml
+++ b/pom.xml
@@ -1,184 +1,175 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
 
-    <prerequisites>
-        <maven>3.6.0</maven>
-    </prerequisites>
-    <modules>
-        <module>schema</module>
-        <module>core</module>
+  <prerequisites>
+    <maven>3.6.0</maven>
+  </prerequisites>
+  <modules>
+    <module>schema</module>
+    <module>core</module>
 
-    </modules>
+  </modules>
 
-    <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <skip.assembly>true</skip.assembly>
-    </properties>
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <skip.assembly>true</skip.assembly>
+  </properties>
 
-    <groupId>eu.alehem.tempserver.remote</groupId>
-    <artifactId>tempremote</artifactId>
-    <version>2.0.0</version>
+  <groupId>eu.alehem.tempserver.remote</groupId>
+  <artifactId>tempremote</artifactId>
+  <version>2.0.0</version>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <generateBackupPoms>false</generateBackupPoms>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                    <configuration>
-                        <release>8</release>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.1</version>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>single</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <archive>
-                            <manifest>
-                                <mainClass>eu.alehem.tempserver.remote.core.Main</mainClass>
-                            </manifest>
-                        </archive>
-                        <descriptorRefs>
-                            <descriptorRef>jar-with-dependencies</descriptorRef>
-                        </descriptorRefs>
-                        <skipAssembly>${skip.assembly}</skipAssembly>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.7</version>
+          <configuration>
+            <generateBackupPoms>false</generateBackupPoms>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <release>11</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.1.1</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <archive>
+              <manifest>
+                <mainClass>eu.alehem.tempserver.remote.core.Main</mainClass>
+              </manifest>
+              <manifestEntries>
+                <Multi-Release>true</Multi-Release>
+              </manifestEntries>
+            </archive>
+            <descriptorRefs>
+              <descriptorRef>jar-with-dependencies</descriptorRef>
+            </descriptorRefs>
+            <skipAssembly>${skip.assembly}</skipAssembly>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
-    <dependencies>
+  <dependencies>
 
-        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.1</version>
-            <scope>test</scope>
-        </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.14.1</version>
+    </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.13.1</version>
-        </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.14.1</version>
+    </dependency>
 
+    <dependency>
+      <groupId>com.pi4j</groupId>
+      <artifactId>pi4j-core</artifactId>
+      <version>1.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.pi4j</groupId>
+          <artifactId>pi4j-native</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
+    <!-- used for the TemperatureSensor interface -->
+    <dependency>
+      <groupId>com.pi4j</groupId>
+      <artifactId>pi4j-device</artifactId>
+      <version>1.1</version>
+    </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.27.2.1</version>
+    </dependency>
 
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-            <scope>runtime</scope>
-        </dependency>
+    <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.3.1</version>
+    </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.11.4</version>
+    </dependency>
 
-        <dependency>
-            <groupId>com.pi4j</groupId>
-            <artifactId>pi4j-core</artifactId>
-            <version>1.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.pi4j</groupId>
-                    <artifactId>pi4j-native</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.8.7</version>
+      <scope>test</scope>
+    </dependency>
 
-        <!-- used for the TemperatureSensor interface -->
-        <dependency>
-            <groupId>com.pi4j</groupId>
-            <artifactId>pi4j-device</artifactId>
-            <version>1.1</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
-        <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>3.27.2.1</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.3.1</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.11.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.8.7</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
-        </dependency>
+    <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.10.0</version>
+      <scope>test</scope>
+    </dependency>
 
 
-        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.5</version>
-        </dependency>
+    <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
-        </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.10</version>
+    </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-all -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+    <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-all -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/schema/src/main/java/eu/alehem/tempserver/remote/schema/JsonProperties.java
+++ b/schema/src/main/java/eu/alehem/tempserver/remote/schema/JsonProperties.java
@@ -4,8 +4,6 @@ import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.UUID;
-
 @AllArgsConstructor
 @Getter
 public final class JsonProperties {


### PR DESCRIPTION
Fixes an issue with log4j that caused the error

`WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.`

For more info on fix, see [this](https://stackoverflow.com/questions/60741008/maven-assembly-plugin-multi-releasetrue)

to be displayed. This also fixes log output in general.

Also Updates to java 11 (I know its like the worst scope-creep but hey)

Run googlestyle aswell because upgrading to 11 was not enough creep.